### PR TITLE
subresource move case

### DIFF
--- a/assets/examples/tutorial-moveResource/Readme.md
+++ b/assets/examples/tutorial-moveResource/Readme.md
@@ -1,0 +1,13 @@
+# Custom pipeline move resource test
+
+This example shows how to use move test.
+
+In moveResourceTest.ts we create a custom pipeline that will do basic forward rendering with move pass involved.
+
+1. first we rendering scene to 6 different texture;
+2. next we move 6 textures produced in step 1 to two 3-slice texture respectively, and then move two 3-slice texture to a 6-slice texture;
+3. sample from 6 slice texture and render to final target.
+
+```typescript 
+rendering.setCustomPipeline('MyPipeline', new HelloWorldPipeline());
+```

--- a/assets/examples/tutorial-moveResource/moveResourceTest.ts
+++ b/assets/examples/tutorial-moveResource/moveResourceTest.ts
@@ -1,0 +1,276 @@
+import {
+    _decorator,
+    Component,
+    gfx,
+    renderer,
+    rendering,
+    Vec3,
+    Material,
+    resources,
+    director,
+    game,
+    Game
+} from 'cc';
+import { JSB } from 'cc/env';
+import { getWindowInfo, WindowInfo } from '../pipeline-data';
+const { ccclass } = _decorator;
+
+import ResourceResidency = rendering.ResourceResidency;
+import ResourceFlags = rendering.ResourceFlags;
+import ResourceDimension = rendering.ResourceDimension;
+import MovePair = rendering.MovePair;
+
+const matArr: { name: string, path: string }[] = [
+    { name: 'sampleTexture', path: 'mat/sampleTexture' },
+];
+
+const materialMap = new Map<string, Material>();
+function loadResource () {
+    for (let pair of matArr) {
+        resources.load(pair.path, Material, (error, material) => {
+            materialMap.set(pair.name, material);
+        });
+    }
+}
+
+// implement a custom pipeline
+// 如何实现一个自定义渲染管线
+class MoveResourcePipeline implements rendering.PipelineBuilder {
+    // implemenation of rendering.PipelineBuilder interface
+    // 实现 rendering.PipelineBuilder 接口
+    public setup (cameras: renderer.scene.Camera[], ppl: rendering.BasicPipeline): void {
+        for (let i = 0; i < cameras.length; i++) {
+            const camera = cameras[i];
+            // skip invalid camera
+            // 跳过无效的摄像机
+            if (camera.scene === null || camera.window === null) {
+                continue;
+            }
+            // prepare camera resources
+            // 准备摄像机资源
+            const info = this.prepareCameraResources(ppl, camera);
+
+            // build forward lighting for editor or game view
+            // 为编辑器以及游戏视图构建前向光照管线
+            this.buildForward(ppl, camera, info.id, info.width, info.height);
+        }
+    }
+    // internal methods
+    // 管线内部方法
+    private prepareCameraResources (
+        ppl: rendering.BasicPipeline,
+        camera: renderer.scene.Camera): WindowInfo {
+        // get window info
+        // 获取窗口信息
+        const info = getWindowInfo(camera);
+        // check if camera resources are initialized
+        // 检查摄像机资源是否已经初始化
+        if (info.width === 0 && info.height === 0) {
+            info.width = camera.window.width;
+            info.height = camera.window.height;
+            this.initCameraResources(ppl, camera, info.id, info.width, info.height);
+        } else if (
+            // we need to check framebuffer because window may be reused
+            // 我们需要检查 framebuffer，因为窗口可能被重用
+            info.framebuffer !== camera.window.framebuffer ||
+            // we need to check width and height because window may be resized
+            // 我们需要检查宽度和高度，因为窗口可能被调整大小
+            info.width !== camera.window.width ||
+            info.height !== camera.window.height) {
+            // resized or invalidated
+            // 调整大小或者失效
+            info.framebuffer = camera.window.framebuffer; // update framebuffer
+            info.width = camera.window.width; // update width
+            info.height = camera.window.height; // update height
+            // update resources
+            // 更新资源
+            this.updateCameraResources(ppl, camera, info.id, info.width, info.height);
+        }
+        // return window info
+        // 返回窗口信息
+        return info;
+    }
+
+
+    private initCameraResources (ppl: rendering.BasicPipeline, camera: renderer.scene.Camera, id: number, width: number, height: number): void {
+        // all resource can be initialized here
+        // 所有资源可以在这里初始化
+        ppl.addRenderWindow(`Color${id}`, gfx.Format.BGRA8, width, height, camera.window);
+        ppl.addDepthStencil(`DepthStencil${id}`, gfx.Format.DEPTH_STENCIL, width, height);
+
+        if (!ppl.containsResource('ctop')) {
+            ppl.addRenderTarget('ctop', gfx.Format.RGBA8, width, height, ResourceResidency.MANAGED);
+            ppl.addRenderTarget('cbottom', gfx.Format.RGBA8, width, height, ResourceResidency.MANAGED);
+            ppl.addRenderTarget('cleft', gfx.Format.RGBA8, width, height, ResourceResidency.MANAGED);
+            ppl.addRenderTarget('cright', gfx.Format.RGBA8, width, height, ResourceResidency.MANAGED);
+            ppl.addRenderTarget('cfront', gfx.Format.RGBA8, width, height, ResourceResidency.MANAGED);
+            ppl.addRenderTarget('crear', gfx.Format.RGBA8, width, height, ResourceResidency.MANAGED);
+
+            ppl.addResource('texArray6', ResourceDimension.TEXTURE2D, gfx.Format.RGBA8, width, height,
+                1, 6, 1, 1,
+                ResourceFlags.COLOR_ATTACHMENT | ResourceFlags.SAMPLED | ResourceFlags.INPUT_ATTACHMENT,
+                ResourceResidency.MANAGED);
+            ppl.addResource('texArray3_0', ResourceDimension.TEXTURE2D, gfx.Format.RGBA8, width, height,
+                1, 3, 1, 1,
+                ResourceFlags.COLOR_ATTACHMENT | ResourceFlags.SAMPLED | ResourceFlags.INPUT_ATTACHMENT,
+                ResourceResidency.MANAGED);
+
+            ppl.addResource('texArray3_1', ResourceDimension.TEXTURE2D, gfx.Format.RGBA8, width, height,
+                1, 3, 1, 1,
+                ResourceFlags.COLOR_ATTACHMENT | ResourceFlags.SAMPLED | ResourceFlags.INPUT_ATTACHMENT,
+                ResourceResidency.MANAGED);
+        }
+    }
+    private updateCameraResources (ppl: rendering.BasicPipeline, camera: renderer.scene.Camera, id: number, width: number, height: number): void {
+        // all resource can be updated here
+        // 所有资源可以在这里更新
+        ppl.updateRenderWindow(`Color${id}`, camera.window);
+        ppl.updateDepthStencil(`DepthStencil${id}`, width, height);
+    }
+
+    private addForwardPass (ppl: rendering.BasicPipeline, cam: renderer.scene.Camera, width: number, height: number, targetName: string, dsName: string, clearColor: gfx.Color) {
+        const pass = ppl.addRenderPass(width, height, 'default');
+        pass.setViewport(this._viewport);
+        pass.addRenderTarget(targetName, gfx.LoadOp.CLEAR, gfx.StoreOp.STORE, clearColor);
+        pass.addDepthStencil(
+            dsName,
+            gfx.LoadOp.CLEAR,
+            gfx.StoreOp.DISCARD,
+            1.0, 0,
+            gfx.ClearFlagBit.DEPTH_STENCIL);
+
+        pass.addQueue(rendering.QueueHint.NONE)
+            .addSceneOfCamera(
+                cam,
+                new rendering.LightInfo(),
+                rendering.SceneFlags.OPAQUE | rendering.SceneFlags.MASK);
+    }
+
+    // build forward lighting pipeline
+    // NOTE: this is just a simple example, you can implement your own pipeline here
+    // In this example, we have turned off shadowmap in the scene
+    // 构建前向光照管线
+    // 注意：这只是一个简单的例子，你可以在这里实现自己的管线
+    // 在这个例子中，我们已经在场景中关闭了阴影贴图
+    private buildForward (
+        ppl: rendering.BasicPipeline,
+        camera: renderer.scene.Camera,
+        id: number, // window id
+        width: number,
+        height: number): void {
+        // prepare camera clear color
+        // 准备摄像机清除颜色
+        this._clearColor.x = camera.clearColor.x;
+        this._clearColor.y = camera.clearColor.y;
+        this._clearColor.z = camera.clearColor.z;
+        this._clearColor.w = camera.clearColor.w;
+
+        // prepare camera viewport
+        // 准备摄像机视口
+        this._viewport.left = camera.viewport.x * width;
+        this._viewport.top = camera.viewport.y * height;
+        this._viewport.width = camera.viewport.z * width;
+        this._viewport.height = camera.viewport.w * height;
+
+        const targets: string[] = ['cright', 'cleft', 'ctop', 'cbottom', 'cfront', 'crear'];
+        const clearColors: gfx.Color[] = [
+            new gfx.Color(1.0, 0.0, 0.0, 1.0),
+            new gfx.Color(0.0, 1.0, 0.0, 1.0),
+            new gfx.Color(0.0, 0.0, 1.0, 1.0),
+            new gfx.Color(1.0, 1.0, 0.0, 1.0),
+            new gfx.Color(1.0, 0.0, 1.0, 1.0),
+            new gfx.Color(0.0, 1.0, 1.0, 1.0),
+        ];
+
+        // 1. 6 passes rendering to 6 resource separately
+        // 1. 分别在6个pass渲染到6个不同的render target
+        for (let i = 0; i < 6; ++i) {
+            this.addForwardPass(ppl, camera, width, height, targets[i], `DepthStencil${id}`, clearColors[i]);
+        }
+        // camera.node.setRotationFromEuler(euler);
+
+        if (JSB) {
+            // 2. move resources which are not overlapped and have same resource description
+            // 2. 对同样性质且不重叠的资源进行move
+            const advancedPipeline = ppl as rendering.Pipeline;
+            { // optional move test, move to a 3-slices texture first, a 3-slices texture view will be created in resource graph. 
+                // 2.1 move ctop/cbottom/cleft 3 textures to a single 3-slice texArray3_0. 
+                // 2.1 把 ctop/cbottom/cleft 3个texture move到一个具有3个slice的纹理数组texArray3_0上
+                let mvs0 = [];
+                mvs0.push(new MovePair('ctop', 'texArray3_0', 1, 1, 0, 0, 0));
+                mvs0.push(new MovePair('cbottom', 'texArray3_0', 1, 1, 0, 1, 0));
+                mvs0.push(new MovePair('cleft', 'texArray3_0', 1, 1, 0, 2, 0));
+                advancedPipeline.addMovePass(mvs0);
+            }
+            {// optional move test, move rest faces to a 3-slices texture, a 3-slices texture view will be created in resource graph.
+                // 2.2 move cright/cfront/crear 3 textures to a single 3-slice texture texArray3_1. 
+                // 2.2 把 cright/cfront/crear 3个texture move到一个具有3个slice的纹理数组texArray3_1上
+                let mvs1 = [];
+                mvs1.push(new MovePair('cright', 'texArray3_1', 1, 1, 0, 0, 0));
+                mvs1.push(new MovePair('cfront', 'texArray3_1', 1, 1, 0, 1, 0));
+                mvs1.push(new MovePair('crear', 'texArray3_1', 1, 1, 0, 2, 0));
+                advancedPipeline.addMovePass(mvs1);
+            }
+            {
+                // 2.3 move texArray3_0 and texArray3_1 to a single 6-layer texArray6 respectively. 
+                // 2.3 把 texArray3_0 和 texArray3_1 move到一个具有6个slice的纹理数组texArray6上
+                const move0 = new MovePair('texArray3_0', 'texArray6', 1, 3, 0, 0, 0);
+                const move1 = new MovePair('texArray3_1', 'texArray6', 1, 3, 0, 3, 0);
+                advancedPipeline.addMovePass([move0, move1]);
+            }
+        }
+
+        const subW = width / 3;
+        const subH = height / 2;
+        const vp: gfx.Viewport[] = [
+            new gfx.Viewport(0, 0, subW, subH),
+            new gfx.Viewport(subW, 0, subW, subH),
+            new gfx.Viewport(subW * 2, 0, subW, subH),
+            new gfx.Viewport(0, subH, subW, subH),
+            new gfx.Viewport(subW, subH, subW, subH),
+            new gfx.Viewport(subW * 2, subH, subW, subH),
+        ];
+        // 3. rendeirng to final screen on 6 different area and sample from different slices of texArray6
+        // 3. 从texArray6不同slice上采样并渲染至屏幕上
+        for (let i = 0; i < 6; ++i) {
+            const loadOp = i === 0 ? gfx.LoadOp.CLEAR : gfx.LoadOp.LOAD;
+
+            const samplePass = ppl.addRenderPass(width, height, 'sampleTexture');
+            samplePass.addRenderTarget(`Color${id}`, loadOp, gfx.StoreOp.STORE, new gfx.Color());
+
+            const samplerInfo = new gfx.SamplerInfo(gfx.Filter.POINT, gfx.Filter.POINT, gfx.Filter.POINT);
+            const pointSampler = director.root.device.getSampler(samplerInfo);
+            samplePass.addTexture('texArray6', 'mainTexture', pointSampler, i);
+            const queue = samplePass.addQueue(rendering.QueueHint.NONE, 'sampleTexture-phase');
+            queue.setViewport(vp[i]);
+            queue.addFullscreenQuad(materialMap.get('sampleTexture'),
+                0,
+                rendering.SceneFlags.OPAQUE);
+
+        }
+    }
+    // internal cached resources
+    // 管线内部缓存资源
+    readonly _clearColor = new gfx.Color(0, 0, 0, 1);
+    readonly _viewport = new gfx.Viewport();
+}
+
+// register pipeline
+// 注册管线
+rendering.setCustomPipeline('MyPipeline', new MoveResourcePipeline());
+
+@ccclass('pipeline_001')
+export class pipeline_001 extends Component {
+    start () {
+        // noop
+        // 空操作
+    }
+    update (deltaTime: number) {
+        // noop
+        // 空操作
+    }
+}
+
+game.on(Game.EVENT_RENDERER_INITED, () => {
+    loadResource();
+});

--- a/assets/examples/tutorial-moveResource/moveResourceTest.ts
+++ b/assets/examples/tutorial-moveResource/moveResourceTest.ts
@@ -194,19 +194,19 @@ class MoveResourcePipeline implements rendering.PipelineBuilder {
             // 2. 对同样性质且不重叠的资源进行move
             const advancedPipeline = ppl as rendering.Pipeline;
             { // optional move test, move to a 3-slices texture first, a 3-slices texture view will be created in resource graph. 
-                // 2.1 move ctop/cbottom/cleft 3 textures to a single 3-slice texArray3_0. 
-                // 2.1 把 ctop/cbottom/cleft 3个texture move到一个具有3个slice的纹理数组texArray3_0上
+                // 2.1 move cright/cleft/ctop 3 textures to a single 3-slice texArray3_0. 
+                // 2.1 把 cright/cleft/ctop 3个texture move到一个具有3个slice的纹理数组texArray3_0上
                 let mvs0 = [];
-                mvs0.push(new MovePair('ctop', 'texArray3_0', 1, 1, 0, 0, 0));
-                mvs0.push(new MovePair('cbottom', 'texArray3_0', 1, 1, 0, 1, 0));
-                mvs0.push(new MovePair('cleft', 'texArray3_0', 1, 1, 0, 2, 0));
+                mvs0.push(new MovePair('cright', 'texArray3_0', 1, 1, 0, 0, 0));
+                mvs0.push(new MovePair('cleft', 'texArray3_0', 1, 1, 0, 1, 0));
+                mvs0.push(new MovePair('ctop', 'texArray3_0', 1, 1, 0, 2, 0));
                 advancedPipeline.addMovePass(mvs0);
             }
             {// optional move test, move rest faces to a 3-slices texture, a 3-slices texture view will be created in resource graph.
-                // 2.2 move cright/cfront/crear 3 textures to a single 3-slice texture texArray3_1. 
-                // 2.2 把 cright/cfront/crear 3个texture move到一个具有3个slice的纹理数组texArray3_1上
+                // 2.2 move cbottom/cfront/crear 3 textures to a single 3-slice texture texArray3_1. 
+                // 2.2 把 cbottom/cfront/crear 3个texture move到一个具有3个slice的纹理数组texArray3_1上
                 let mvs1 = [];
-                mvs1.push(new MovePair('cright', 'texArray3_1', 1, 1, 0, 0, 0));
+                mvs1.push(new MovePair('cbottom', 'texArray3_1', 1, 1, 0, 0, 0));
                 mvs1.push(new MovePair('cfront', 'texArray3_1', 1, 1, 0, 1, 0));
                 mvs1.push(new MovePair('crear', 'texArray3_1', 1, 1, 0, 2, 0));
                 advancedPipeline.addMovePass(mvs1);
@@ -266,9 +266,44 @@ export class pipeline_001 extends Component {
         // 空操作
     }
     update (deltaTime: number) {
-        // noop
-        // 空操作
+        // find main camera
+        // 找到相机节点
+        let camNode;
+        for (let comp of director.getScene().children) {
+            if (comp && comp.name === 'Main Camera') {
+                camNode = comp;
+            }
+        }
+        if (camNode) {
+            // update position and rotation
+            // 更新位置和旋转
+            const stepDegree = (360 / 8) / 60;
+            const currAng = this._accAng;
+            const pos = camNode.position;
+            const rot = camNode.eulerAngles;
+
+            const newRot = new Vec3(rot);
+            newRot.y += stepDegree;
+
+            const radius = pos.length();
+            const rad = currAng * Math.PI / 180;
+            const x = radius * Math.sin(rad);
+            const z = radius * Math.cos(rad);
+            const newPos = new Vec3(pos);
+            newPos.x = x;
+            newPos.z = z;
+
+            camNode.setPosition(newPos);
+            camNode.setRotationFromEuler(newRot);
+
+            this._accAng += stepDegree;
+            if (this._accAng > 360) {
+                this._accAng -= 360;
+            }
+        }
     }
+
+    _accAng: number = 0;
 }
 
 game.on(Game.EVENT_RENDERER_INITED, () => {

--- a/assets/examples/tutorial-moveResource/scene-moveResource.scene
+++ b/assets/examples/tutorial-moveResource/scene-moveResource.scene
@@ -1,0 +1,570 @@
+[
+  {
+    "__type__": "cc.SceneAsset",
+    "_name": "scene-moveResource",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "_native": "",
+    "scene": {
+      "__id__": 1
+    }
+  },
+  {
+    "__type__": "cc.Scene",
+    "_name": "scene-moveResource",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "_parent": null,
+    "_children": [
+      {
+        "__id__": 2
+      },
+      {
+        "__id__": 5
+      },
+      {
+        "__id__": 8
+      }
+    ],
+    "_active": true,
+    "_components": [],
+    "_prefab": {
+      "__id__": 16
+    },
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_mobility": 0,
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "autoReleaseAssets": false,
+    "_globals": {
+      "__id__": 17
+    },
+    "_id": "dc85a4ee-1fa8-43a7-abb5-36993fc279c4"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Light",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 3
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": -0.06397656665577071,
+      "y": -0.44608233363525845,
+      "z": -0.8239028751062036,
+      "w": -0.3436591377065261
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_mobility": 0,
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": -117.894,
+      "y": -194.909,
+      "z": 38.562
+    },
+    "_id": "c0y6F5f+pAvI805TdmxIjx"
+  },
+  {
+    "__type__": "cc.DirectionalLight",
+    "_name": "",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 250,
+      "b": 240,
+      "a": 255
+    },
+    "_useColorTemperature": false,
+    "_colorTemperature": 6550,
+    "_staticSettings": {
+      "__id__": 4
+    },
+    "_visibility": -325058561,
+    "_illuminanceHDR": 65000,
+    "_illuminance": 65000,
+    "_illuminanceLDR": 1.6927083333333335,
+    "_shadowEnabled": false,
+    "_shadowPcf": 0,
+    "_shadowBias": 0.00001,
+    "_shadowNormalBias": 0,
+    "_shadowSaturation": 1,
+    "_shadowDistance": 50,
+    "_shadowInvisibleOcclusionRange": 200,
+    "_csmLevel": 4,
+    "_csmLayerLambda": 0.75,
+    "_csmOptimizationMode": 2,
+    "_csmAdvancedOptions": false,
+    "_csmLayersTransition": false,
+    "_csmTransitionRange": 0.05,
+    "_shadowFixedArea": false,
+    "_shadowNear": 0.1,
+    "_shadowFar": 10,
+    "_shadowOrthoSize": 5,
+    "_id": "597uMYCbhEtJQc0ffJlcgA"
+  },
+  {
+    "__type__": "cc.StaticLightSettings",
+    "_baked": false,
+    "_editorOnly": false,
+    "_castShadow": false
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Camera",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 6
+      },
+      {
+        "__id__": 7
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 20
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_mobility": 0,
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "c9DMICJLFO5IeO07EPon7U"
+  },
+  {
+    "__type__": "cc.Camera",
+    "_name": "",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "node": {
+      "__id__": 5
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_projection": 1,
+    "_priority": 0,
+    "_fov": 45,
+    "_fovAxis": 0,
+    "_orthoHeight": 10,
+    "_near": 1,
+    "_far": 1000,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 67,
+      "g": 101,
+      "b": 189,
+      "a": 255
+    },
+    "_depth": 1,
+    "_stencil": 0,
+    "_clearFlags": 7,
+    "_rect": {
+      "__type__": "cc.Rect",
+      "x": 0,
+      "y": 0,
+      "width": 1,
+      "height": 1
+    },
+    "_aperture": 19,
+    "_shutter": 7,
+    "_iso": 0,
+    "_screenScale": 1,
+    "_visibility": 1822425087,
+    "_targetTexture": null,
+    "_postProcess": null,
+    "_usePostProcess": false,
+    "_cameraType": -1,
+    "_trackingType": 0,
+    "_id": "7dWQTpwS5LrIHnc1zAPUtf"
+  },
+  {
+    "__type__": "f6c44HQAgVAAaj0rNQiBiz9",
+    "_name": "",
+    "_objFlags": 0,
+    "__editorExtras__": {},
+    "node": {
+      "__id__": 5
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_id": "f5gqXDmlVFbpHgPiotqPxs"
+  },
+  {
+    "__type__": "cc.Node",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_prefab": {
+      "__id__": 9
+    },
+    "__editorExtras__": {}
+  },
+  {
+    "__type__": "cc.PrefabInfo",
+    "root": {
+      "__id__": 8
+    },
+    "asset": {
+      "__uuid__": "0ab3142a-6968-4073-95af-026bc3b23623@cc8e5",
+      "__expectedType__": "cc.Prefab"
+    },
+    "fileId": "ad3FnS56ta95RAYA2aAG4A",
+    "instance": {
+      "__id__": 10
+    },
+    "targetOverrides": null,
+    "nestedPrefabInstanceRoots": null
+  },
+  {
+    "__type__": "cc.PrefabInstance",
+    "fileId": "84C4QuTiNAn7rGSxwAB0to",
+    "prefabRootNode": null,
+    "mountedChildren": [],
+    "mountedComponents": [],
+    "propertyOverrides": [
+      {
+        "__id__": 11
+      },
+      {
+        "__id__": 13
+      },
+      {
+        "__id__": 14
+      },
+      {
+        "__id__": 15
+      }
+    ],
+    "removedComponents": []
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 12
+    },
+    "propertyPath": [
+      "_name"
+    ],
+    "value": "islands"
+  },
+  {
+    "__type__": "cc.TargetInfo",
+    "localID": [
+      "ad3FnS56ta95RAYA2aAG4A"
+    ]
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 12
+    },
+    "propertyPath": [
+      "_lpos"
+    ],
+    "value": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 12
+    },
+    "propertyPath": [
+      "_lrot"
+    ],
+    "value": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    }
+  },
+  {
+    "__type__": "CCPropertyOverrideInfo",
+    "targetInfo": {
+      "__id__": 12
+    },
+    "propertyPath": [
+      "_euler"
+    ],
+    "value": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  {
+    "__type__": "cc.PrefabInfo",
+    "root": null,
+    "asset": null,
+    "fileId": "dc85a4ee-1fa8-43a7-abb5-36993fc279c4",
+    "instance": null,
+    "targetOverrides": null,
+    "nestedPrefabInstanceRoots": [
+      {
+        "__id__": 8
+      }
+    ]
+  },
+  {
+    "__type__": "cc.SceneGlobals",
+    "ambient": {
+      "__id__": 18
+    },
+    "shadows": {
+      "__id__": 19
+    },
+    "_skybox": {
+      "__id__": 20
+    },
+    "fog": {
+      "__id__": 21
+    },
+    "octree": {
+      "__id__": 22
+    },
+    "skin": {
+      "__id__": 23
+    },
+    "lightProbeInfo": {
+      "__id__": 24
+    },
+    "bakedWithStationaryMainLight": false,
+    "bakedWithHighpLightmap": false
+  },
+  {
+    "__type__": "cc.AmbientInfo",
+    "_skyColorHDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.5,
+      "z": 0.8,
+      "w": 0.520833125
+    },
+    "_skyColor": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.5,
+      "z": 0.8,
+      "w": 0.520833125
+    },
+    "_skyIllumHDR": 20000,
+    "_skyIllum": 20000,
+    "_groundAlbedoHDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.2,
+      "z": 0.2,
+      "w": 1
+    },
+    "_groundAlbedo": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.2,
+      "z": 0.2,
+      "w": 1
+    },
+    "_skyColorLDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.452588,
+      "y": 0.607642,
+      "z": 0.755699,
+      "w": 0
+    },
+    "_skyIllumLDR": 0.8,
+    "_groundAlbedoLDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.618555,
+      "y": 0.577848,
+      "z": 0.544564,
+      "w": 0
+    }
+  },
+  {
+    "__type__": "cc.ShadowsInfo",
+    "_enabled": false,
+    "_type": 0,
+    "_normal": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 1,
+      "z": 0
+    },
+    "_distance": 0,
+    "_shadowColor": {
+      "__type__": "cc.Color",
+      "r": 76,
+      "g": 76,
+      "b": 76,
+      "a": 255
+    },
+    "_maxReceived": 4,
+    "_size": {
+      "__type__": "cc.Vec2",
+      "x": 1024,
+      "y": 1024
+    }
+  },
+  {
+    "__type__": "cc.SkyboxInfo",
+    "_envLightingType": 0,
+    "_envmapHDR": {
+      "__uuid__": "d032ac98-05e1-4090-88bb-eb640dcb5fc1@b47c0",
+      "__expectedType__": "cc.TextureCube"
+    },
+    "_envmap": {
+      "__uuid__": "d032ac98-05e1-4090-88bb-eb640dcb5fc1@b47c0",
+      "__expectedType__": "cc.TextureCube"
+    },
+    "_envmapLDR": {
+      "__uuid__": "6f01cf7f-81bf-4a7e-bd5d-0afc19696480@b47c0",
+      "__expectedType__": "cc.TextureCube"
+    },
+    "_diffuseMapHDR": null,
+    "_diffuseMapLDR": null,
+    "_enabled": true,
+    "_useHDR": true,
+    "_editableMaterial": null,
+    "_reflectionHDR": null,
+    "_reflectionLDR": null,
+    "_rotationAngle": 0
+  },
+  {
+    "__type__": "cc.FogInfo",
+    "_type": 0,
+    "_fogColor": {
+      "__type__": "cc.Color",
+      "r": 200,
+      "g": 200,
+      "b": 200,
+      "a": 255
+    },
+    "_enabled": false,
+    "_fogDensity": 0.3,
+    "_fogStart": 0.5,
+    "_fogEnd": 300,
+    "_fogAtten": 5,
+    "_fogTop": 1.5,
+    "_fogRange": 1.2,
+    "_accurate": false
+  },
+  {
+    "__type__": "cc.OctreeInfo",
+    "_enabled": false,
+    "_minPos": {
+      "__type__": "cc.Vec3",
+      "x": -1024,
+      "y": -1024,
+      "z": -1024
+    },
+    "_maxPos": {
+      "__type__": "cc.Vec3",
+      "x": 1024,
+      "y": 1024,
+      "z": 1024
+    },
+    "_depth": 8
+  },
+  {
+    "__type__": "cc.SkinInfo",
+    "_enabled": true,
+    "_blurRadius": 0.01,
+    "_sssIntensity": 3
+  },
+  {
+    "__type__": "cc.LightProbeInfo",
+    "_giScale": 1,
+    "_giSamples": 1024,
+    "_bounces": 2,
+    "_reduceRinging": 0,
+    "_showProbe": true,
+    "_showWireframe": true,
+    "_showConvex": false,
+    "_data": null,
+    "_lightProbeSphereVolume": 1
+  }
+]

--- a/assets/resources/mat/sampleTexture.effect
+++ b/assets/resources/mat/sampleTexture.effect
@@ -35,11 +35,6 @@ CCProgram unlit-fs %{
   precision highp float;
   in vec2 v_uv;
 
-  #pragma rate Index pass
-  uniform Index {
-    int sliceIndex;
-  };
-
   #pragma rate mainTexture pass
   uniform sampler2D mainTexture;
 

--- a/assets/resources/mat/sampleTexture.effect
+++ b/assets/resources/mat/sampleTexture.effect
@@ -1,0 +1,50 @@
+// Effect Syntax Guide: https://docs.cocos.com/creator/manual/zh/shader/index.html
+
+CCEffect %{
+  techniques:
+  - name: opaque
+    passes:
+    - vert: standard-vs:vert
+      frag: unlit-fs:frag
+      pass: sampleTexture
+      phase: sampleTexture-phase
+}%
+
+CCProgram standard-vs %{
+  precision highp float;
+  #include <legacy/input>
+  #include <builtin/uniforms/cc-global>
+  #include <legacy/decode-base>
+  #include <legacy/local-batch>
+  #include <legacy/input>
+  #include <legacy/fog-vs>
+
+  layout(location = 1) out vec2 v_uv;
+
+  vec4 vert () {
+    vec4 position;
+    CCVertInput(position);
+    vec4 pos = cc_matProj * cc_matView * position;
+    v_uv = (pos.xy + 1.0) * 0.5;
+
+    return pos;
+  }
+}%
+
+CCProgram unlit-fs %{
+  precision highp float;
+  in vec2 v_uv;
+
+  #pragma rate Index pass
+  uniform Index {
+    int sliceIndex;
+  };
+
+  #pragma rate mainTexture pass
+  uniform sampler2D mainTexture;
+
+  vec4 frag () {
+    return texture(mainTexture, v_uv);
+  }
+
+}%

--- a/assets/resources/mat/sampleTexture.mtl
+++ b/assets/resources/mat/sampleTexture.mtl
@@ -1,0 +1,35 @@
+{
+  "__type__": "cc.Material",
+  "_name": "",
+  "_objFlags": 0,
+  "__editorExtras__": {},
+  "_native": "",
+  "_effectAsset": {
+    "__uuid__": "4ed72555-48de-4f37-9320-a10800196ea3",
+    "__expectedType__": "cc.EffectAsset"
+  },
+  "_techIdx": 0,
+  "_defines": [
+    {}
+  ],
+  "_states": [
+    {
+      "rasterizerState": {
+        "cullMode": 0,
+        "isDepthClip": false
+      },
+      "depthStencilState": {
+        "depthTest": false,
+        "depthWrite": false
+      },
+      "blendState": {
+        "targets": [
+          {}
+        ]
+      }
+    }
+  ],
+  "_props": [
+    {}
+  ]
+}


### PR DESCRIPTION
add move test case.
expect output:
![image](https://github.com/star-e/cocos-pipeline-examples/assets/18626925/afaa5a4e-82e5-4bc2-9076-635356b51e69)

add a new folder `resources` under assets for the demand of:
```
resources.load(pair.path, Material, (error, material) => {
    materialMap.set(pair.name, material);
});
```
the first parameter of `resources.load` only accepts path under `assets/resources`.