### PR TITLE
subpass in out case

### DIFF
--- a/assets/examples/tutorial-004-subpass-inout.meta
+++ b/assets/examples/tutorial-004-subpass-inout.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "1.2.0",
+  "importer": "directory",
+  "imported": true,
+  "uuid": "1a8eb642-81fa-4b02-8828-fa8eeee13371",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/examples/tutorial-004-subpass-inout/Readme.md
+++ b/assets/examples/tutorial-004-subpass-inout/Readme.md
@@ -1,0 +1,16 @@
+# Custom pipeline subpass in and out test
+
+This example shows how to use subpass.
+
+In subpassInOut.ts we create a custom pipeline that drawing solid color and compose them by subpass.
+
+1. First write to 4 attachment respectively: {resource name: shader slot name} -> {`cOne`: `cFirst`}, {`cTwo`: `cSecond`}, {`cThree`: `cThird`}, {`cFour`: `cForth`};
+2. Read `cOne` and `cTwo` then write to `cFive`;
+3. Read `cThree` and `cFour`, read `cFive` then write to `cFive`;
+4. Copy `cFive` to swapchain.
+
+The `g`(or `y`) component of swapchain is 0.4, which comes from subpass 0, this validates the {`cFour`: `cForth`} won't be reordered in the front of  {`cTwo`: `cSecond`}, {`cThree`: `cThird`},; 
+
+```typescript 
+rendering.setCustomPipeline('SubpassInOut', new HelloWorldPipeline());
+```

--- a/assets/examples/tutorial-004-subpass-inout/Readme.md.meta
+++ b/assets/examples/tutorial-004-subpass-inout/Readme.md.meta
@@ -1,0 +1,1 @@
+{"ver":"1.0.2","importer":"text","imported":true,"uuid":"b3d2dd61-fff3-49ff-a245-3d476cdf5876","files":[".json"],"subMetas":{},"userData":{}}

--- a/assets/examples/tutorial-004-subpass-inout/pipeline-004.scene
+++ b/assets/examples/tutorial-004-subpass-inout/pipeline-004.scene
@@ -1,0 +1,317 @@
+[
+  {
+    "__type__": "cc.SceneAsset",
+    "_name": "pipeline-004",
+    "_objFlags": 0,
+    "_native": "",
+    "scene": {
+      "__id__": 1
+    }
+  },
+  {
+    "__type__": "cc.Scene",
+    "_name": "",
+    "_objFlags": 0,
+    "_parent": null,
+    "_children": [
+      {
+        "__id__": 2
+      },
+      {
+        "__id__": 5
+      }
+    ],
+    "_active": true,
+    "_components": [],
+    "_prefab": null,
+    "autoReleaseAssets": false,
+    "_globals": {
+      "__id__": 7
+    },
+    "_id": "e737597f-df7f-4882-8dca-e2d1d813d0b3"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Light",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 3
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": -0.06397656665577071,
+      "y": -0.44608233363525845,
+      "z": -0.8239028751062036,
+      "w": -0.3436591377065261
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": -117.894,
+      "y": -194.909,
+      "z": 38.562
+    },
+    "_id": "c0y6F5f+pAvI805TdmxIjx"
+  },
+  {
+    "__type__": "cc.DirectionalLight",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 250,
+      "b": 240,
+      "a": 255
+    },
+    "_useColorTemperature": false,
+    "_colorTemperature": 6550,
+    "_staticSettings": {
+      "__id__": 4
+    },
+    "_illuminanceHDR": 65000,
+    "_illuminance": 65000,
+    "_illuminanceLDR": 1.6927083333333335,
+    "_id": "597uMYCbhEtJQc0ffJlcgA"
+  },
+  {
+    "__type__": "cc.StaticLightSettings",
+    "_baked": false,
+    "_editorOnly": false,
+    "_bakeable": false,
+    "_castShadow": false
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Camera",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 6
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": -10,
+      "y": 10,
+      "z": 10
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": -0.27781593346944056,
+      "y": -0.36497167621709875,
+      "z": -0.11507512748638377,
+      "w": 0.8811195706053617
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": -35,
+      "y": -45,
+      "z": 0
+    },
+    "_id": "c9DMICJLFO5IeO07EPon7U"
+  },
+  {
+    "__type__": "cc.Camera",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 5
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_projection": 1,
+    "_priority": 0,
+    "_fov": 45,
+    "_fovAxis": 0,
+    "_orthoHeight": 10,
+    "_near": 1,
+    "_far": 1000,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 51,
+      "g": 51,
+      "b": 51,
+      "a": 255
+    },
+    "_depth": 1,
+    "_stencil": 0,
+    "_clearFlags": 14,
+    "_rect": {
+      "__type__": "cc.Rect",
+      "x": 0,
+      "y": 0,
+      "width": 1,
+      "height": 1
+    },
+    "_aperture": 19,
+    "_shutter": 7,
+    "_iso": 0,
+    "_screenScale": 1,
+    "_visibility": 1822425087,
+    "_targetTexture": null,
+    "_id": "7dWQTpwS5LrIHnc1zAPUtf"
+  },
+  {
+    "__type__": "cc.SceneGlobals",
+    "ambient": {
+      "__id__": 8
+    },
+    "shadows": {
+      "__id__": 9
+    },
+    "_skybox": {
+      "__id__": 10
+    },
+    "fog": {
+      "__id__": 11
+    }
+  },
+  {
+    "__type__": "cc.AmbientInfo",
+    "_skyColorHDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.365754,
+      "y": 0.568107,
+      "z": 0.9080791,
+      "w": 0
+    },
+    "_skyIllumHDR": 20000,
+    "_skyIllum": 20000,
+    "_groundAlbedoHDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.455624,
+      "y": 0.403274,
+      "z": 0.370948,
+      "w": 0
+    },
+    "_skyColorLDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.452588,
+      "y": 0.607642,
+      "z": 0.755699,
+      "w": 0
+    },
+    "_skyIllumLDR": 0.8,
+    "_groundAlbedoLDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.618555,
+      "y": 0.577848,
+      "z": 0.544564,
+      "w": 0
+    }
+  },
+  {
+    "__type__": "cc.ShadowsInfo",
+    "_type": 0,
+    "_enabled": false,
+    "_normal": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 1,
+      "z": 0
+    },
+    "_distance": 0,
+    "_shadowColor": {
+      "__type__": "cc.Color",
+      "r": 76,
+      "g": 76,
+      "b": 76,
+      "a": 255
+    },
+    "_firstSetCSM": false,
+    "_fixedArea": false,
+    "_pcf": 1,
+    "_bias": 0.00001,
+    "_normalBias": 0,
+    "_near": 0.1,
+    "_far": 10,
+    "_shadowDistance": 10,
+    "_invisibleOcclusionRange": 200,
+    "_orthoSize": 5,
+    "_maxReceived": 4,
+    "_size": {
+      "__type__": "cc.Vec2",
+      "x": 1024,
+      "y": 1024
+    },
+    "_saturation": 0.75
+  },
+  {
+    "__type__": "cc.SkyboxInfo",
+    "_applyDiffuseMap": false,
+    "_envmapHDR": {
+      "__uuid__": "d032ac98-05e1-4090-88bb-eb640dcb5fc1@b47c0",
+      "__expectedType__": "cc.TextureCube"
+    },
+    "_envmap": {
+      "__uuid__": "d032ac98-05e1-4090-88bb-eb640dcb5fc1@b47c0",
+      "__expectedType__": "cc.TextureCube"
+    },
+    "_envmapLDR": {
+      "__uuid__": "6f01cf7f-81bf-4a7e-bd5d-0afc19696480@b47c0",
+      "__expectedType__": "cc.TextureCube"
+    },
+    "_diffuseMapHDR": null,
+    "_diffuseMapLDR": null,
+    "_enabled": true,
+    "_useIBL": false,
+    "_useHDR": true
+  },
+  {
+    "__type__": "cc.FogInfo",
+    "_type": 0,
+    "_fogColor": {
+      "__type__": "cc.Color",
+      "r": 200,
+      "g": 200,
+      "b": 200,
+      "a": 255
+    },
+    "_enabled": false,
+    "_fogDensity": 0.3,
+    "_fogStart": 0.5,
+    "_fogEnd": 300,
+    "_fogAtten": 5,
+    "_fogTop": 1.5,
+    "_fogRange": 1.2
+  }
+]

--- a/assets/examples/tutorial-004-subpass-inout/pipeline-004.scene.meta
+++ b/assets/examples/tutorial-004-subpass-inout/pipeline-004.scene.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.1.49",
+  "importer": "scene",
+  "imported": true,
+  "uuid": "e737597f-df7f-4882-8dca-e2d1d813d0b3",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/examples/tutorial-004-subpass-inout/subpassInOut.ts
+++ b/assets/examples/tutorial-004-subpass-inout/subpassInOut.ts
@@ -1,0 +1,211 @@
+import {
+    _decorator,
+    cclegacy,
+    Component,
+    geometry,
+    gfx,
+    Material,
+    renderer,
+    rendering,
+    resources,
+} from 'cc';
+import { getWindowInfo, WindowInfo } from '../pipeline-data';
+const { ccclass } = _decorator;
+
+import CopyPair = rendering.CopyPair;
+
+
+function addOrUpdateRenderTarget(name: string, format: gfx.Format, width: number, height: number, residency: rendering.ResourceResidency, pipeline: rendering.Pipeline) {
+    if (!pipeline.containsResource(name)) {
+        pipeline.addRenderTarget(name, format, width, height, residency);
+    } else {
+        pipeline.updateRenderTarget(name, width, height);
+    }
+}
+
+const matArr: { name: string, path: string }[] = [
+    { name: 'subpassMat0', path: 'subpassInOut/subpass0' },
+    { name: 'subpassMat1', path: 'subpassInOut/subpass1' },
+    { name: 'subpassMat2', path: 'subpassInOut/subpass2' },
+];
+
+const materialMap = new Map<string, Material>();
+function loadResource() {
+    for (let pair of matArr) {
+        resources.load(pair.path, Material, (error, material) => {
+            materialMap.set(pair.name, material);
+        });
+    }
+}
+
+// implement a custom pipeline
+// 如何实现一个自定义渲染管线
+class SubpassInOutPipeline implements rendering.PipelineBuilder {
+    // implemenation of rendering.PipelineBuilder interface
+    // 实现 rendering.PipelineBuilder 接口
+    public setup(cameras: renderer.scene.Camera[], ppl: rendering.BasicPipeline): void {
+        for (let i = 0; i < cameras.length; i++) {
+            const camera = cameras[i];
+            // skip invalid camera
+            // 跳过无效的摄像机
+            if (camera.scene === null || camera.window === null) {
+                continue;
+            }
+            // prepare camera resources
+            // 准备摄像机资源
+            const info = this.prepareCameraResources(ppl, camera);
+
+            // build forward lighting for editor or game view
+            // 为编辑器以及游戏视图构建前向光照管线
+            this.buildForward(ppl, camera, info.id, info.width, info.height);
+        }
+    }
+    // internal methods
+    // 管线内部方法
+    private prepareCameraResources(
+        ppl: rendering.BasicPipeline,
+        camera: renderer.scene.Camera): WindowInfo {
+        // get window info
+        // 获取窗口信息
+        const info = getWindowInfo(camera);
+        // check if camera resources are initialized
+        // 检查摄像机资源是否已经初始化
+        if (info.width === 0 && info.height === 0) {
+            info.width = camera.window.width;
+            info.height = camera.window.height;
+            this.initCameraResources(ppl, camera, info.id, info.width, info.height);
+        } else if (
+            // we need to check framebuffer because window may be reused
+            // 我们需要检查 framebuffer，因为窗口可能被重用
+            info.framebuffer !== camera.window.framebuffer ||
+            // we need to check width and height because window may be resized
+            // 我们需要检查宽度和高度，因为窗口可能被调整大小
+            info.width !== camera.window.width ||
+            info.height !== camera.window.height) {
+            // resized or invalidated
+            // 调整大小或者失效
+            info.framebuffer = camera.window.framebuffer; // update framebuffer
+            info.width = camera.window.width; // update width
+            info.height = camera.window.height; // update height
+            // update resources
+            // 更新资源
+            this.updateCameraResources(ppl, camera, info.id, info.width, info.height);
+        }
+        // return window info
+        // 返回窗口信息
+        return info;
+    }
+    private supportsR32FloatTexture(device: gfx.Device) {
+        return (device.getFormatFeatures(gfx.Format.R32F) & (gfx.FormatFeatureBit.RENDER_TARGET | gfx.FormatFeatureBit.SAMPLED_TEXTURE))
+            === (gfx.FormatFeatureBit.RENDER_TARGET | gfx.FormatFeatureBit.SAMPLED_TEXTURE)
+            && !(device.gfxAPI === gfx.API.WEBGL); // wegl 1  Single-channel float type is not supported under webgl1, so it is excluded
+    }
+
+    private initCameraResources(ppl: rendering.BasicPipeline, camera: renderer.scene.Camera, id: number, width: number, height: number): void {
+        // all resource can be initialized here
+        // 所有资源可以在这里初始化
+        ppl.addRenderWindow(`Color${id}`, gfx.Format.BGRA8, width, height, camera.window);
+        ppl.addDepthStencil(`DepthStencil${id}`, gfx.Format.DEPTH_STENCIL, width, height);
+        // CSM
+        const shadowFormat = this.supportsR32FloatTexture(ppl.device) ? gfx.Format.R32F : gfx.Format.RGBA8;
+        const shadowSize = ppl.pipelineSceneData.shadows.size;
+        ppl.addRenderTarget(`ShadowMap${id}`, shadowFormat, shadowSize.x, shadowSize.y);
+        ppl.addDepthStencil(`ShadowDepth${id}`, gfx.Format.DEPTH_STENCIL, shadowSize.x, shadowSize.y);
+    }
+    private updateCameraResources(ppl: rendering.BasicPipeline, camera: renderer.scene.Camera, id: number, width: number, height: number): void {
+        // all resource can be updated here
+        // 所有资源可以在这里更新
+        ppl.updateRenderWindow(`Color${id}`, camera.window);
+        ppl.updateDepthStencil(`DepthStencil${id}`, width, height);
+        // CSM
+        const shadowSize = ppl.pipelineSceneData.shadows.size;
+        ppl.updateRenderTarget(`ShadowMap${id}`, shadowSize.x, shadowSize.y);
+        ppl.updateDepthStencil(`ShadowDepth${id}`, shadowSize.x, shadowSize.y);
+    }
+
+    // build a subpass test pipeline; usage shown below
+    // 构建前一个subpass测例
+    private buildForward(
+        ppl: rendering.BasicPipeline,
+        camera: renderer.scene.Camera,
+        id: number, // window id
+        width: number,
+        height: number): void {
+
+        const pipeline = ppl as rendering.Pipeline;
+        addOrUpdateRenderTarget("cOne", gfx.Format.RGBA8, width, height, rendering.ResourceResidency.MEMORYLESS, pipeline);
+        addOrUpdateRenderTarget("cTwo", gfx.Format.RGBA8, width, height, rendering.ResourceResidency.MEMORYLESS, pipeline);
+        addOrUpdateRenderTarget("cThree", gfx.Format.RGBA8, width, height, rendering.ResourceResidency.MEMORYLESS, pipeline);
+        addOrUpdateRenderTarget("cFour", gfx.Format.RGBA8, width, height, rendering.ResourceResidency.MEMORYLESS, pipeline);
+        addOrUpdateRenderTarget("cFive", gfx.Format.RGBA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);
+        // addOrUpdateRenderTarget("ds", gfx.Format.DEPTH, width, height, rendering.ResourceResidency.MEMORYLESS, pipeline);
+
+        const clearColor = new gfx.Color(0, 0, 0, 0);
+        const builder = pipeline.addRenderPass(width, height, 'subpassInOut');
+        const subpass0 = builder.addRenderSubpass('subpass0');
+        // 'cFirst'
+        subpass0.addRenderTarget("cOne", rendering.AccessType.WRITE, "_", gfx.LoadOp.CLEAR, gfx.StoreOp.DISCARD, clearColor);
+        // 'cSecond'
+        subpass0.addRenderTarget("cTwo", rendering.AccessType.WRITE, "_", gfx.LoadOp.CLEAR, gfx.StoreOp.DISCARD, clearColor);
+        // 'cThird'
+        subpass0.addRenderTarget("cThree", rendering.AccessType.WRITE, "_", gfx.LoadOp.CLEAR, gfx.StoreOp.DISCARD, clearColor);
+        // 'cForth'
+        subpass0.addRenderTarget("cFour", rendering.AccessType.WRITE, "_", gfx.LoadOp.CLEAR, gfx.StoreOp.DISCARD, clearColor);
+        subpass0
+            .addQueue(rendering.QueueHint.RENDER_OPAQUE, 'subpass0-phase0')
+            .addFullscreenQuad(materialMap.get('subpassMat0'), 0);
+
+        const subpass1 = builder.addRenderSubpass('subpass1');
+        subpass1.addRenderTarget("cOne", rendering.AccessType.READ, "cInZ", gfx.LoadOp.DISCARD, gfx.StoreOp.STORE, clearColor);
+        subpass1.addRenderTarget("cTwo", rendering.AccessType.READ, "cInA", gfx.LoadOp.DISCARD, gfx.StoreOp.STORE, clearColor);
+        subpass1.addRenderTarget("cFive", rendering.AccessType.WRITE, "color", gfx.LoadOp.CLEAR, gfx.StoreOp.STORE, clearColor);
+
+        subpass1
+            .addQueue(rendering.QueueHint.RENDER_OPAQUE, 'subpass1-phase0')
+            .addFullscreenQuad(materialMap.get('subpassMat1'), 0);
+
+        const subpass2 = builder.addRenderSubpass('subpass2');
+        subpass2.addRenderTarget("cFour", rendering.AccessType.READ, "c1", gfx.LoadOp.LOAD, gfx.StoreOp.DISCARD, clearColor);
+        subpass2.addRenderTarget("cThree", rendering.AccessType.READ, "c0", gfx.LoadOp.LOAD, gfx.StoreOp.DISCARD, clearColor);
+        subpass2.addRenderTarget("cFive", rendering.AccessType.READ_WRITE, "color", gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
+
+        subpass2
+            .addQueue(rendering.QueueHint.RENDER_OPAQUE, 'subpass2-phase0')
+            .addFullscreenQuad(materialMap.get('subpassMat2'), 0);
+
+        const forwardPassRTName = `Color${id}`;
+        const copy = new CopyPair('cFive', forwardPassRTName, 1, 1, 0, 0, 0, 0, 0, 0);
+        pipeline.addCopyPass([copy]);
+    }
+    // internal cached resources
+    // 管线内部缓存资源
+    // pipeline
+    readonly _clearColor = new gfx.Color(0, 0, 0, 1);
+    readonly _viewport = new gfx.Viewport();
+    readonly _flipY = cclegacy.director.root.device.capabilities.screenSpaceSignY;
+    // scene
+    readonly _sphere = geometry.Sphere.create(0, 0, 0, 1);
+    readonly _boundingBox = new geometry.AABB();
+    readonly _rangedDirLightBoundingBox = new geometry.AABB(0.0, 0.0, 0.0, 0.5, 0.5, 0.5);
+    // valid lights
+    readonly lights: renderer.scene.Light[] = [];
+    readonly spotLights: renderer.scene.SpotLight[] = [];
+}
+
+// register pipeline
+// 注册管线
+rendering.setCustomPipeline('SubpassInOut', new SubpassInOutPipeline());
+
+loadResource();
+
+@ccclass('pipeline_004_subpass_in_out')
+export class pipeline_004_subpass_in_out extends Component {
+    start() {
+        // noop
+        // 空操作
+    }
+    update(deltaTime: number) {
+        // noop
+        // 空操作
+    }
+}

--- a/assets/examples/tutorial-004-subpass-inout/subpassInOut.ts.meta
+++ b/assets/examples/tutorial-004-subpass-inout/subpassInOut.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.23",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "20748436-b7a5-454d-ab2d-946f4b4581d7",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut.meta
+++ b/assets/resources/subpassInOut.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "1.2.0",
+  "importer": "directory",
+  "imported": true,
+  "uuid": "8b32e75d-8f57-4af7-872e-a5825dcb734b",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut/subpass0.effect
+++ b/assets/resources/subpassInOut/subpass0.effect
@@ -1,0 +1,49 @@
+// Effect Syntax Guide: https://docs.cocos.com/creator/manual/zh/shader/index.html
+
+CCEffect %{
+  techniques:
+  - name: opaque
+    passes:
+    - vert: standard-vs:vert
+      frag: standard-fs
+      pass: subpassInOut
+      subpass: subpass0
+      phase: subpass0-phase0
+}%
+
+
+CCProgram standard-vs %{
+  precision highp float;
+  #include <legacy/input>
+  #include <builtin/uniforms/cc-global>
+  #include <legacy/decode-base>
+  #include <legacy/local-batch>
+  #include <legacy/input>
+  #include <legacy/fog-vs>
+
+
+  vec4 vert () {
+    vec4 position;
+    CCVertInput(position);
+
+    return cc_matProj * cc_matView * position;
+  }
+}%
+
+
+CCProgram standard-fs %{
+  precision mediump float;
+
+  #pragma subpass
+  #pragma subpassColor out cFirst
+  #pragma subpassColor out cSecond
+  #pragma subpassColor out cThird
+  #pragma subpassColor out cForth
+
+  void main () {
+    cFirst = vec4(1, 0, 0, 1);
+    cSecond = vec4(0, 1, 0, 1);
+    cThird = vec4(0, 0, 0.5, 1);
+    cForth = vec4(0, 0.4, 0.0, 1);
+  }
+}%

--- a/assets/resources/subpassInOut/subpass0.effect.meta
+++ b/assets/resources/subpassInOut/subpass0.effect.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.7.1",
+  "importer": "effect",
+  "imported": true,
+  "uuid": "94358209-2bcc-4d0e-9991-1bdeaae363f5",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut/subpass0.mtl
+++ b/assets/resources/subpassInOut/subpass0.mtl
@@ -1,0 +1,31 @@
+{
+  "__type__": "cc.Material",
+  "_name": "",
+  "_objFlags": 0,
+  "__editorExtras__": {},
+  "_native": "",
+  "_effectAsset": {
+    "__uuid__": "94358209-2bcc-4d0e-9991-1bdeaae363f5",
+    "__expectedType__": "cc.EffectAsset"
+  },
+  "_techIdx": 0,
+  "_defines": [
+    {}
+  ],
+  "_states": [
+    {
+      "rasterizerState": {
+        "cullMode": 0
+      },
+      "depthStencilState": {},
+      "blendState": {
+        "targets": [
+          {}
+        ]
+      }
+    }
+  ],
+  "_props": [
+    {}
+  ]
+}

--- a/assets/resources/subpassInOut/subpass0.mtl.meta
+++ b/assets/resources/subpassInOut/subpass0.mtl.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.0.21",
+  "importer": "material",
+  "imported": true,
+  "uuid": "3db13c39-db6c-407a-93b4-6a5c508a3695",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut/subpass1.effect
+++ b/assets/resources/subpassInOut/subpass1.effect
@@ -1,0 +1,47 @@
+// Effect Syntax Guide: https://docs.cocos.com/creator/manual/zh/shader/index.html
+
+CCEffect %{
+  techniques:
+  - name: opaque
+    passes:
+    - vert: standard-vs:vert
+      frag: standard-fs
+      pass: subpassInOut
+      subpass: subpass1
+      phase: subpass1-phase0
+}%
+
+
+CCProgram standard-vs %{
+  precision highp float;
+  #include <legacy/input>
+  #include <builtin/uniforms/cc-global>
+  #include <legacy/decode-base>
+  #include <legacy/local-batch>
+  #include <legacy/input>
+  #include <legacy/fog-vs>
+
+
+  vec4 vert () {
+    vec4 position;
+    CCVertInput(position);
+
+    return cc_matProj * cc_matView * position;
+  }
+}%
+
+
+CCProgram standard-fs %{
+  precision mediump float;
+  
+  #pragma subpass
+  #pragma subpassColor out color
+  #pragma subpassColor in cInZ
+  #pragma subpassColor in cInA
+
+  void main () {
+    vec4 v0 = subpassLoad(cInZ);
+    vec4 v1 = subpassLoad(cInA);
+    color = v1 * 0.8 + v0 * 0.2;
+  }
+}%

--- a/assets/resources/subpassInOut/subpass1.effect.meta
+++ b/assets/resources/subpassInOut/subpass1.effect.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.7.1",
+  "importer": "effect",
+  "imported": true,
+  "uuid": "61b0dafb-5078-4d32-af66-2ee8f7479e06",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut/subpass1.mtl
+++ b/assets/resources/subpassInOut/subpass1.mtl
@@ -1,0 +1,31 @@
+{
+  "__type__": "cc.Material",
+  "_name": "",
+  "_objFlags": 0,
+  "__editorExtras__": {},
+  "_native": "",
+  "_effectAsset": {
+    "__uuid__": "61b0dafb-5078-4d32-af66-2ee8f7479e06",
+    "__expectedType__": "cc.EffectAsset"
+  },
+  "_techIdx": 0,
+  "_defines": [
+    {}
+  ],
+  "_states": [
+    {
+      "rasterizerState": {
+        "cullMode": 0
+      },
+      "depthStencilState": {},
+      "blendState": {
+        "targets": [
+          {}
+        ]
+      }
+    }
+  ],
+  "_props": [
+    {}
+  ]
+}

--- a/assets/resources/subpassInOut/subpass1.mtl.meta
+++ b/assets/resources/subpassInOut/subpass1.mtl.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.0.21",
+  "importer": "material",
+  "imported": true,
+  "uuid": "7f59270d-04ee-4de5-ab60-7500919a4b10",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut/subpass2.effect
+++ b/assets/resources/subpassInOut/subpass2.effect
@@ -1,0 +1,53 @@
+// Effect Syntax Guide: https://docs.cocos.com/creator/manual/zh/shader/index.html
+
+CCEffect %{
+  techniques:
+  - name: opaque
+    passes:
+    - vert: standard-vs:vert
+      frag: standard-fs
+      pass: subpassInOut
+      subpass: subpass2
+      phase: subpass2-phase0
+}%
+
+
+CCProgram standard-vs %{
+  precision highp float;
+  #include <legacy/input>
+  #include <builtin/uniforms/cc-global>
+  #include <legacy/decode-base>
+  #include <legacy/local-batch>
+  #include <legacy/input>
+  #include <legacy/fog-vs>
+
+
+  vec4 vert () {
+    vec4 position;
+    CCVertInput(position);
+
+    return cc_matProj * cc_matView * position;
+  }
+}%
+
+
+CCProgram standard-fs %{
+  precision mediump float;
+
+  layout(std140) uniform Constants {
+    vec4 baseColor;
+  };
+
+  #pragma subpass
+  #pragma subpassColor in c0
+  #pragma subpassColor in c1
+  #pragma subpassColor inout color
+
+  void main () {
+    vec4 v0 = subpassLoad(c0);
+    vec4 v1 = subpassLoad(c1);
+    vec4 vo = subpassLoad(color);
+    color = vo * 0.5 + v0 + v1;
+    color.g = v1.g;
+  }
+}%

--- a/assets/resources/subpassInOut/subpass2.effect.meta
+++ b/assets/resources/subpassInOut/subpass2.effect.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.7.1",
+  "importer": "effect",
+  "imported": true,
+  "uuid": "007fecb9-3847-47c0-a287-5f3752365dbb",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/resources/subpassInOut/subpass2.mtl
+++ b/assets/resources/subpassInOut/subpass2.mtl
@@ -1,0 +1,31 @@
+{
+  "__type__": "cc.Material",
+  "_name": "",
+  "_objFlags": 0,
+  "__editorExtras__": {},
+  "_native": "",
+  "_effectAsset": {
+    "__uuid__": "007fecb9-3847-47c0-a287-5f3752365dbb",
+    "__expectedType__": "cc.EffectAsset"
+  },
+  "_techIdx": 0,
+  "_defines": [
+    {}
+  ],
+  "_states": [
+    {
+      "rasterizerState": {
+        "cullMode": 0
+      },
+      "depthStencilState": {},
+      "blendState": {
+        "targets": [
+          {}
+        ]
+      }
+    }
+  ],
+  "_props": [
+    {}
+  ]
+}

--- a/assets/resources/subpassInOut/subpass2.mtl.meta
+++ b/assets/resources/subpassInOut/subpass2.mtl.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.0.21",
+  "importer": "material",
+  "imported": true,
+  "uuid": "f1787ed2-7068-405d-a9fe-8dcb040b55bd",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}


### PR DESCRIPTION
# Custom pipeline subpass in and out test

This example shows how to use subpass.

In subpassInOut.ts we create a custom pipeline that drawing solid color and compose them by subpass.

1. First write to 4 attachment respectively: {resource name: shader slot name} -> {`cOne`: `cFirst`}, {`cTwo`: `cSecond`}, {`cThree`: `cThird`}, {`cFour`: `cForth`};
2. Read `cOne` and `cTwo` then write to `cFive`;
3. Read `cThree` and `cFour`, read `cFive` then write to `cFive`;
4. Copy `cFive` to swapchain.

The `g`(or `y`) component of swapchain is 0.4, which comes from subpass 0, this validates the {`cFour`: `cForth`} won't be reordered in the front of  {`cTwo`: `cSecond`}, {`cThree`: `cThird`},; 

```typescript 
rendering.setCustomPipeline('SubpassInOut', new HelloWorldPipeline());
```